### PR TITLE
seccomp: allow madvise(*, *, MADV_DONTNEED)

### DIFF
--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -23,6 +23,7 @@ pub const ALLOWED_SYSCALLS: &[i64] = &[
     libc::SYS_futex,
     libc::SYS_ioctl,
     libc::SYS_lseek,
+    libc::SYS_madvise,
     libc::SYS_mmap,
     libc::SYS_munmap,
     libc::SYS_open,
@@ -240,6 +241,20 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
             (
                 libc::SYS_lseek,
                 (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+            ),
+            (
+                libc::SYS_madvise,
+                (
+                    0,
+                    vec![SeccompRule::new(
+                        vec![SeccompCondition::new(
+                            2,
+                            SeccompCmpOp::Eq,
+                            libc::MADV_DONTNEED as u64,
+                        )?],
+                        SeccompAction::Allow,
+                    )],
+                ),
             ),
             (
                 libc::SYS_mmap,


### PR DESCRIPTION
The musl allocator calls it to punch holes in large chunks of allocated memory:
https://elixir.bootlin.com/musl/v1.1.20/source/src/malloc/malloc.c#L501
